### PR TITLE
removed setuptools as a dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,4 @@ web3==5.0.0
 eth-account==0.4.0
 pytest>=4.4.0,<5.0.0
 tox==3.13.2
-setuptools==41.0.1
 eth_keys

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ REQUIREMENTS = [
     'eth-account==0.4.0',
     'pytest>=4.4.0,<5.0.0',
     'tox==3.13.2',
-    'setuptools==41.0.1',
     'eth_keys'
 ]
 


### PR DESCRIPTION
You don't really have your dependencies under control.

The install_requires in `setup.py` should list the minimal packages needed to run it. So not setuptools, and not tox, and not pytest. These all belong in a `requirements-dev.txt` or similar.

I needed this fix because I have the latest setuptools, which broke everything.