### PR TITLE
v0.10.4: make sure amount is an int regardless of args

### DIFF
--- a/dydx/client.py
+++ b/dydx/client.py
@@ -112,7 +112,7 @@ class Client(object):
             'isBuy': isBuy,
             'baseMarket': baseMarket,
             'quoteMarket': quoteMarket,
-            'amount': amount,
+            'amount': int(float(amount)),
             'limitPrice': price,
             'triggerPrice': Decimal(0),
             'limitFee': limitFee,
@@ -172,7 +172,7 @@ class Client(object):
         order = {
             'salt': random.randint(0, 2**256),
             'isBuy': isBuy,
-            'amount': amount,
+            'amount': int(float(amount)),
             'limitPrice': price,
             'triggerPrice': Decimal(0),
             'limitFee': limitFee,

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ REQUIREMENTS = [
 
 setup(
     name='dydx-python',
-    version='0.10.3',
+    version='0.10.4',
     packages=find_packages(),
     package_data={
         'dydx': ['abi/*.json'],


### PR DESCRIPTION
- fixes https://github.com/dydxprotocol/dydx-python/issues/58
- amount can be passed in as a float or a string and orderbook won't throw