### PR TITLE
Publish the project with the `publish` requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 LONG_DESCRIPTION = open('README.md', 'r').read()
 
-REQUIREMENTS = open('requirements.txt', 'r').read().split('\n')
+REQUIREMENTS = open('requirements-publish.txt', 'r').read().split('\n')
 
 setup(
     name='dydx-python',


### PR DESCRIPTION
Currently, installing `dydx-python` requires `pytest>=4.4.0,<5.0.0`. This PR switches to publishing the project with the `requirements-publish.txt` which does not contain the development requirements.